### PR TITLE
minor UI changes for streaming with OBS

### DIFF
--- a/src/components/gameLayout/gameLayout.tsx
+++ b/src/components/gameLayout/gameLayout.tsx
@@ -467,6 +467,7 @@ export const GameLayout = () => {
                     {...zoneProps}
                     name={ZoneName.Exile}
                     contents={gameZonesState[ZoneName.Exile]}
+                    disablePreview={true}
                     showTopOnly={true}
                 />
             </div>

--- a/src/components/gameLayout/gameLayout.tsx
+++ b/src/components/gameLayout/gameLayout.tsx
@@ -452,6 +452,7 @@ export const GameLayout = () => {
                     {...zoneProps}
                     name={ZoneName.Hand}
                     contents={gameZonesState[ZoneName.Hand]}
+                    disablePreview={true}
                 />
                 <StackZone
                     {...zoneProps}

--- a/src/components/gameLayout/searchZone.tsx
+++ b/src/components/gameLayout/searchZone.tsx
@@ -49,6 +49,8 @@ export const SearchZone = ({ zone, contents, requestClose }: SearchZoneProps) =>
         c.label.toLowerCase().includes(searchString)
     );
 
+    if (zone == "library") options.sort((a,b) => (a.label.localeCompare(b.label)));
+
     const [selectedIndex, setSelectedIndex] = useState<number>(0);
     const normalizedIndex = Math.min(selectedIndex, options.length - 1);
     const selectedZoneCard = normalizedIndex >= 0 ? options[normalizedIndex].zoneCard : undefined;

--- a/src/components/gameLayout/stackZone.tsx
+++ b/src/components/gameLayout/stackZone.tsx
@@ -8,11 +8,12 @@ import { CurrentDragInfo } from "./gameLayout";
 
 interface StackZoneProps extends ZoneProps {
     showTopOnly?: boolean;
+    disablePreview?: boolean;
     vertical?: boolean;
 }
 
 export const StackZone = forwardRef((props: StackZoneProps, ref) => {
-    const { contents, showTopOnly, vertical, onCardMouseEnter } = props;
+    const { contents, showTopOnly, disablePreview, vertical, onCardMouseEnter } = props;
 
     const [previewingCard, setPreviewingCard] = useDebouncedValue<CardInfo>(undefined, 100);
 
@@ -55,7 +56,7 @@ export const StackZone = forwardRef((props: StackZoneProps, ref) => {
     });
 
     const fireCardMouseEnter = (action: CurrentDragInfo) => {
-        if (!showTopOnly) setPreviewingCard(action.zoneCard.card);
+        if (!disablePreview) setPreviewingCard(action.zoneCard.card);
         return onCardMouseEnter ? onCardMouseEnter(action) : true;
     };
 


### PR DESCRIPTION
to support streaming this page with OBS to play on spelltable, given that OBS will allow you to block out the hand zone
- sort the library alphabetically so a player does not see the order of their entire deck when they search it
- disable card preview when hovering over cards in the hand zone (and exile just to make existing behavior)